### PR TITLE
Align ERC8004 quiz routes

### DIFF
--- a/spoon-core/LOCAL_RUN.md
+++ b/spoon-core/LOCAL_RUN.md
@@ -63,8 +63,8 @@ Quiz flow (frontend):
 
 ERC-8004 quiz flow (frontend):
 
-1) `POST /erc8004/quiz/start`
-2) `POST /erc8004/quiz/answer` (repeat 3 times with `sessionId`)
+1) `POST /tutor/erc8004/quiz/start`
+2) `POST /tutor/erc8004/quiz/answer` (repeat 3 times with `sessionId`)
 
 If the frontend runs on another device, set:
 
@@ -95,8 +95,8 @@ Then test:
 - `POST /tutor/1559/quiz/answer`
 - `POST /tutor/7702/quiz/start`
 - `POST /tutor/7702/quiz/answer`
-- `POST /erc8004/quiz/start`
-- `POST /erc8004/quiz/answer`
+- `POST /tutor/erc8004/quiz/start`
+- `POST /tutor/erc8004/quiz/answer`
 
 Example `POST /tutor/1559/explain` body:
 
@@ -150,10 +150,10 @@ Example ERC-8004 quiz flow:
 
 ```bash
 # Start
-curl -s http://127.0.0.1:8009/erc8004/quiz/start
+curl -s http://127.0.0.1:8009/tutor/erc8004/quiz/start
 
 # Answer (replace sessionId)
-curl -s http://127.0.0.1:8009/erc8004/quiz/answer \
+curl -s http://127.0.0.1:8009/tutor/erc8004/quiz/answer \
   -H 'Content-Type: application/json' \
   -d '{
     "sessionId": "REPLACE_ME",

--- a/spoon-core/examples/TUTOR_SERVICE.md
+++ b/spoon-core/examples/TUTOR_SERVICE.md
@@ -198,11 +198,11 @@ Request/response shapes are the same as the 1559 quiz.
 
 Start:
 
-- `POST /erc8004/quiz/start`
+- `POST /tutor/erc8004/quiz/start`
 
 Answer:
 
-- `POST /erc8004/quiz/answer`
+- `POST /tutor/erc8004/quiz/answer`
 
 Request/response shapes are the same as the 1559 quiz.
 

--- a/spoon-core/spoon_ai/tutor/service.py
+++ b/spoon-core/spoon_ai/tutor/service.py
@@ -859,11 +859,11 @@ async def tutor_7702_quiz_answer(req: QuizAnswerRequest) -> QuizResponse:
     return await _quiz_answer("7702", req)
 
 
-@app.post("/erc8004/quiz/start", response_model=QuizResponse)
+@app.post("/tutor/erc8004/quiz/start", response_model=QuizResponse)
 async def erc8004_quiz_start() -> QuizResponse:
     return await _quiz_start("erc8004")
 
 
-@app.post("/erc8004/quiz/answer", response_model=QuizResponse)
+@app.post("/tutor/erc8004/quiz/answer", response_model=QuizResponse)
 async def erc8004_quiz_answer(req: QuizAnswerRequest) -> QuizResponse:
     return await _quiz_answer("erc8004", req)


### PR DESCRIPTION
Align ERC8004 quiz endpoints under /tutor/erc8004/quiz/* to match EIP-7702 route structure.
Keep quiz response fields unchanged (sessionId, done, questionIndex, assistantMessage, passed).
 Update docs/examples to use the new endpoints.